### PR TITLE
start_logging fix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -120,8 +120,7 @@ fn main() {
     }
 
     if let Err(e) = start_logging() {
-        error!("Logging failed to start: {:?}", e);
-        println!("[!!] Logging failed to start: {:?}", e);
+	panic!("[!!] Logging failed to start: {:?}", e);
     }
     
     info!("Starting application");


### PR DESCRIPTION
On Debian if the XDG_DATA_HOME env var isn't set and the directory expected by the dirs crate cannot be created the app crashes on cargo run --release.  

I just swapped create_dir to create_dir_all in the start_logging function so it can create the entire path if necessary.

Also tried to make that function more 'rust-like' by returning a result from start_logging and the panicking if starting the logging fails.  Rust-noob though so could be totally wrong also :)