### PR TITLE
Implements support for binding keys from lua. Fixes #66

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "blightmud"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The client is written in rust. Some navigating throught the thesaurus brought me
     - Timers
     - Customizing status bar
     - Persistent storage
+    - Keybindings
 - Low resource and fast
 - In client help and manuals
 - Tab completion

--- a/resources/completions.txt
+++ b/resources/completions.txt
@@ -1,1 +1,1 @@
-/connect /quit /disconnect /add_server /remove_server /list_servers /load /help scripting /logging /start_log /stop_log /set logging_enabled logging config_scripts aliases triggers timers gmcp status_area echo_gmcp storage
+/connect /quit /disconnect /add_server /remove_server /list_servers /load /help scripting /logging /start_log /stop_log /set logging_enabled logging config_scripts aliases triggers timers gmcp status_area echo_gmcp storage bindings

--- a/resources/help/bindings.md
+++ b/resources/help/bindings.md
@@ -1,0 +1,67 @@
+# Bindings
+
+It is possible bind certain key commands in lua script to perform actions when
+pressed. This also include rebinding keys to a setup you are more comfortable
+with rather then the default.
+
+Currently bindings are limited to the following options:
+
+- `Ctrl-<char>` eg. `Ctrl-a, Ctrl-b` but not `Ctrl-PgUp`, there is no distinction for capitalization
+- `Alt-<char>` eg. `Alt-a, Alt-b` but not `Alt-PgUp`, there is no distinction for capitalization
+- `F1-F12`
+
+***blight:bind(cmd, callback)***
+Is the command to use when creating a binding.
+
+`cmd` has to be in the following format:
+- `Ctrl-{}` where {} is a character, eg. a, b, c, etc.
+- `Alt-{}` where {} is a character, eg. a, b, c, etc.
+- `fn` where n is a number from 1-12
+
+```lua
+blight:bind("f1", function ()
+    blight:send("kick " .. target)
+end)
+```
+
+***blight:unbind(cmd)***
+Is the command to use when you want to remove a binding
+You can't unbind `Ctrl-c` or `Ctrl-l`
+
+***blight:ui(cmd)***
+Allows for interactions with the UI.
+
+The following options are available for `cmd`:
+- `"step_left"`         : Moves the cursor left
+- `"step_right"`        : Moves the cursor right
+- `"step_to_start"`     : Moves the cursor to the start of the input line
+- `"step_to_end"`       : Moves cursor to the end of the input line
+- `"step_word_left"`    : Moves cursor left by one word
+- `"step_word_right"`   : Moves cursor right by one word
+- `"delete"`            : Deletes the character before the cursor
+- `"delete_to_end"`     : Deletes from the cursor to the end of the line
+- `"delete_from_start"` : Deletes from the start of the input line to the cursor
+- `"previous_command"`  : Get the previous input command
+- `"next_command"`      : Get the next input command
+- `"scroll_up"`         : Scroll output view up
+- `"scroll_down"`       : Scroll output view down
+- `"scroll_bottom"`     : Scroll the output view to the bottom
+- `"complete"`          : Perform *tab-completion* on the current word
+
+What follows is the default configuration that blightmud starts with. You can
+override this as you please using `blight:unbind` and `blight:bind`
+
+```lua
+local function bind(cmd, event)
+	blight:bind(cmd, function () blight:ui(event) end)
+end
+
+bind("ctrl-p", "previous_command")
+bind("ctrl-n", "next_command")
+bind("alt-b", "step_word_left")
+bind("alt-f", "step_word_right")
+bind("ctrl-a", "step_to_start")
+bind("ctrl-e", "step_to_end")
+bind("ctrl-k", "delete_to_end")
+bind("ctrl-u", "delete_from_start")
+```

--- a/resources/help/help.md
+++ b/resources/help/help.md
@@ -24,7 +24,7 @@ Helpfiles can also be viewed [online](https://github.com/LiquidityC/Blightmud/tr
 - `/quit`, `/q`                      : Exit program
 - `/help`                            : Help information
 
-## Basic operations:
+## Default keybindings:
 
 - `PgUp`/`PgDn`      : Scroll output view
 - `End`              : Go to bottom of output view
@@ -38,3 +38,5 @@ Helpfiles can also be viewed [online](https://github.com/LiquidityC/Blightmud/tr
 - `Ctrl-U`           : Delete from start of input line to cursor
 - `Ctrl-L`           : Redraw screen (good when muds mess stuff up)
 - `Ctrl-C`           : Quit program
+
+To change keybindings see `/help scripting` and `/help bindings`

--- a/resources/help/scripting.md
+++ b/resources/help/scripting.md
@@ -19,3 +19,4 @@ by typing `/help <category>`.
 - `gmcp`        Methods for interacting with the Generic MUD Communication Protocol.
 - `status_area` Methods for controlling and printing to the status bar
 - `storage`     Methods for persisting data between sessions
+- `bindings`    Methods for configuring keybindings and adding new ones

--- a/resources/lua/bindings.lua
+++ b/resources/lua/bindings.lua
@@ -1,0 +1,12 @@
+local function bind(cmd, event)
+	blight:bind(cmd, function () blight:ui(event) end)
+end
+
+bind("ctrl-p", "previous_command")
+bind("ctrl-n", "next_command")
+bind("alt-b", "step_word_left")
+bind("alt-f", "step_word_right")
+bind("ctrl-a", "step_to_start")
+bind("ctrl-e", "step_to_end")
+bind("ctrl-k", "delete_to_end")
+bind("ctrl-u", "delete_from_start")

--- a/src/lua/constants.rs
+++ b/src/lua/constants.rs
@@ -7,3 +7,4 @@ pub const ON_DISCONNECT_CALLBACK: &str = "__disconnect_callback";
 pub const ON_GMCP_READY_CALLBACK: &str = "__gmcp_enabled_callback";
 pub const TIMED_FUNCTION_TABLE: &str = "__timed_functions";
 pub const GAG_NEXT_TRIGGER_LINE: &str = "__gag_next";
+pub const COMMAND_BINDING_TABLE: &str = "__cmd_binds";

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -1,7 +1,9 @@
 pub use self::lua_script::LuaScript;
+pub use self::ui_event::UiEvent;
 
 mod constants;
 mod lua_script;
 mod store_data;
+mod ui_event;
 mod user_data;
 mod util;

--- a/src/lua/ui_event.rs
+++ b/src/lua/ui_event.rs
@@ -1,0 +1,18 @@
+#[derive(Clone)]
+pub enum UiEvent {
+    StepLeft,
+    StepRight,
+    StepToStart,
+    StepToEnd,
+    StepWordLeft,
+    StepWordRight,
+    Remove,
+    DeleteToEnd,
+    DeleteFromStart,
+    PreviousCommand,
+    NextCommand,
+    ScrollUp,
+    ScrollDown,
+    ScrollBottom,
+    Complete,
+}

--- a/src/model/line.rs
+++ b/src/model/line.rs
@@ -46,6 +46,16 @@ impl fmt::Display for Line {
     }
 }
 
+impl From<&Line> for Line {
+    fn from(line: &Line) -> Self {
+        Self {
+            content: line.content.clone(),
+            clean_content: line.clean_content.clone(),
+            flags: line.flags.clone(),
+        }
+    }
+}
+
 impl From<&str> for Line {
     fn from(line: &str) -> Self {
         let (content, clean_content) = get_content_from(line);

--- a/src/ui/help_handler.rs
+++ b/src/ui/help_handler.rs
@@ -77,6 +77,7 @@ fn load_files() -> HashMap<&'static str, &'static str> {
     files.insert("welcome", include_str!("../../resources/help/welcome.md"));
     files.insert("logging", include_str!("../../resources/help/logging.md"));
     files.insert("blight", include_str!("../../resources/help/lua_blight.md"));
+    files.insert("bindings", include_str!("../../resources/help/bindings.md"));
     files.insert(
         "status_area",
         include_str!("../../resources/help/lua_status_area.md"),


### PR DESCRIPTION
Example: `blight:bind("ctrl-a", function () end)`