### PR TITLE
Fix status line when used with colour codes

### DIFF
--- a/src/ui/screen.rs
+++ b/src/ui/screen.rs
@@ -133,12 +133,25 @@ impl StatusArea {
         )?;
 
         let custom_info = if !custom_info.trim().is_empty() {
-            format!("━ {} ", custom_info.trim())
+            format!(
+                "━ {}{}{} ",
+                custom_info.trim(),
+                color::Fg(color::Reset),
+                color::Fg(color::Green)
+            )
         } else {
             "".to_string()
         };
 
-        write!(screen, "{:━<1$}", custom_info, self.width as usize)?; // Print separator
+        let info_line = Line::from(&custom_info);
+        let stripped_chars = info_line.line().len() - info_line.clean_line().len();
+
+        write!(
+            screen,
+            "{:━<1$}",
+            &custom_info,
+            self.width as usize + stripped_chars
+        )?; // Print separator
         write!(screen, "{}", color::Fg(color::Reset))?;
         Ok(())
     }
@@ -259,6 +272,7 @@ impl Screen {
         self.status_area.set_status_line(line, info);
         self.status_area
             .redraw(&mut self.screen, self.scroll_data.0)?;
+        write!(self.screen, "{}", self.goto_prompt())?;
         Ok(())
     }
 


### PR DESCRIPTION
See #76 
I tried many different ways of fixing this, but in the end, simply pretending the string should be longer than it actually is was the only one that worked.

In particular, I originally wanted to use `String::repeat` to generate the String of line characters that come after the status message. Somehow, the last couple characters were always gone. Even if I made it longer than necessary, the characters would appear in the input area, but at the end of the line there were still characters missing - as if it decided to linebreak early.
No idea what was going on there, so this solution it is.

Tested with a status height of 1 and 2.