### PR TITLE
Improves unterminated prompt handling and resetting of colors

### DIFF
--- a/src/net/telnet.rs
+++ b/src/net/telnet.rs
@@ -145,7 +145,7 @@ impl TelnetHandler {
                 && !output_buffer.is_empty()
                 && output_buffer.len() < 80
             {
-                output_buffer.buffer_to_prompt(false);
+                output_buffer.buffer_to_prompt(true);
                 self.main_writer.send(Event::Prompt).unwrap();
             }
         }

--- a/src/ui/screen.rs
+++ b/src/ui/screen.rs
@@ -313,8 +313,14 @@ impl Screen {
         Ok(())
     }
 
-    fn goto_prompt(&self) -> termion::cursor::Goto {
-        termion::cursor::Goto(self.cursor_prompt_pos, self.prompt_line)
+    fn goto_prompt(&self) -> String {
+        format!(
+            "{}{}{}{}",
+            termion::cursor::Goto(self.cursor_prompt_pos, self.prompt_line),
+            color::Fg(color::Reset),
+            color::Bg(color::Reset),
+            termion::style::Reset,
+        )
     }
 
     pub fn reset(&mut self) -> Result<()> {


### PR DESCRIPTION
After testing a new mud I had some issues with rogue colors due to not
being reset by the mud as well as some weird prompt issues. This commit
addresses all of those issues.