### PR TITLE
Changes delete_word_* to share move_word_*'s behavior

### DIFF
--- a/src/ui/command.rs
+++ b/src/ui/command.rs
@@ -163,31 +163,19 @@ impl CommandBuffer {
     }
 
     fn delete_word_right(&mut self) {
-        let origin = (self.cursor_pos).min(self.buffer.len());
-        let start = self.buffer[origin..]
-            .find(|c| c != ' ')
-            .map(|c| c + origin)
-            .unwrap_or(origin);
-        if let Some(pos) = self.buffer[start..].find(' ') {
-            self.buffer.replace_range(origin..start + pos, "");
-        } else if origin < self.buffer.len() {
-            self.buffer.replace_range(origin.., "");
+        let origin = self.cursor_pos;
+        self.move_word_right();
+        if origin != self.cursor_pos {
+            self.buffer.replace_range(origin..self.cursor_pos, "");
+            self.cursor_pos = origin;
         }
     }
 
     fn delete_word_left(&mut self) {
-        if self.cursor_pos == 0 {
-            return;
-        }
-        let origin = self.cursor_pos.max(1);
-        let start = self.buffer[..origin].rfind(|c| c != ' ').unwrap_or(origin);
-        if let Some(pos) = self.buffer[..start].rfind(' ') {
-            let pos = pos + 1;
-            self.cursor_pos = pos;
-            self.buffer.replace_range(pos..origin, "");
-        } else {
-            self.cursor_pos = 0;
-            self.buffer.replace_range(..origin, "");
+        let origin = self.cursor_pos;
+        self.move_word_left();
+        if origin != self.cursor_pos {
+            self.buffer.replace_range(self.cursor_pos..origin, "");
         }
     }
 


### PR DESCRIPTION
I woke up this morning and thought, "*Dear Lord, what have I done?!*"

Instead of doing a bunch of questionable byte dancing, this implementation just re-uses `move_word_right()` and `move_word_left()`. I think it's less surprising for the user, too, since now all the "word" commands have the same behavior.

The tests pass unchanged so there shouldn't be any real difference, other than edge cases.

Original PR: #142