### PR TITLE
Optional mouse support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -132,6 +132,7 @@ fn main() {
         "tts",
         "Use the TTS system when playing a MUD (for visually impaired users)",
     );
+    opts.optflag("M", "mouse", "Enable experimental mouse support");
     opts.optopt("w", "world", "Connect to a predefined world", "WORLD");
     opts.optflag("h", "help", "Print help menu");
     opts.optflag("v", "version", "Print version information");
@@ -150,6 +151,8 @@ fn main() {
         print_version();
         return;
     }
+
+    let wants_mouse = matches.opt_present("M");
 
     register_panic_hook();
     if let Err(e) = start_logging() {
@@ -192,6 +195,7 @@ fn main() {
         .main_writer(main_writer)
         .timer_writer(timer_writer)
         .screen_dimensions(dimensions)
+        .mouse_enabled(wants_mouse)
         .tts_enabled(matches.opt_present("tts"))
         .build();
 
@@ -209,7 +213,7 @@ fn run(
     main_thread_read: Receiver<Event>,
     mut session: Session,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let mut screen = Screen::new(session.tts_ctrl.clone())?;
+    let mut screen = Screen::new(session.tts_ctrl.clone(), session.mouse_support)?;
     screen.setup()?;
 
     let mut transmit_writer: Option<Sender<TelnetData>> = None;

--- a/src/session.rs
+++ b/src/session.rs
@@ -20,6 +20,7 @@ pub struct Session {
     pub lua_script: Arc<Mutex<LuaScript>>,
     pub logger: Arc<Mutex<Logger>>,
     pub tts_ctrl: Arc<Mutex<TTSController>>,
+    pub mouse_support: bool,
 }
 
 impl Session {
@@ -117,6 +118,7 @@ pub struct SessionBuilder {
     timer_writer: Option<Sender<TimerEvent>>,
     screen_dimensions: Option<(u16, u16)>,
     tts_enabled: bool,
+    mouse_enabled: bool,
 }
 
 impl SessionBuilder {
@@ -126,6 +128,7 @@ impl SessionBuilder {
             timer_writer: None,
             screen_dimensions: None,
             tts_enabled: false,
+            mouse_enabled: false,
         }
     }
 
@@ -149,6 +152,11 @@ impl SessionBuilder {
         self
     }
 
+    pub fn mouse_enabled(mut self, enabled: bool) -> Self {
+        self.mouse_enabled = enabled;
+        self
+    }
+
     pub fn build(self) -> Session {
         let main_writer = self.main_writer.unwrap();
         let timer_writer = self.timer_writer.unwrap();
@@ -168,6 +176,7 @@ impl SessionBuilder {
             prompt_input: Arc::new(Mutex::new(String::new())),
             lua_script: Arc::new(Mutex::new(LuaScript::new(main_writer, dimensions))),
             logger: Arc::new(Mutex::new(Logger::default())),
+            mouse_support: self.mouse_enabled,
             tts_ctrl: Arc::new(Mutex::new(TTSController::new(tts_enabled))),
         }
     }

--- a/src/ui/screen.rs
+++ b/src/ui/screen.rs
@@ -219,13 +219,7 @@ impl Screen {
         tts_ctrl: Arc<Mutex<TTSController>>,
         mouse_support: bool,
     ) -> Result<Self, Box<dyn error::Error>> {
-        let screen: Box<dyn Write> = if mouse_support {
-            Box::new(MouseTerminal::from(AlternateScreen::from(
-                stdout().into_raw_mode()?,
-            )))
-        } else {
-            Box::new(AlternateScreen::from(stdout().into_raw_mode()?))
-        };
+        let screen = Self::create_screen_writer(mouse_support)?;
         let (width, height) = termion::terminal_size()?;
 
         let status_area_height = 1;
@@ -536,6 +530,16 @@ impl Screen {
 
     pub fn flush(&mut self) {
         self.screen.flush().unwrap();
+    }
+
+    /// Creates the io::Write terminal handler we draw to.
+    fn create_screen_writer(mouse_support: bool) -> Result<Box<dyn Write>, Box<dyn error::Error>> {
+        let screen = AlternateScreen::from(stdout().into_raw_mode()?);
+        if mouse_support {
+            Ok(Box::new(MouseTerminal::from(screen)))
+        } else {
+            Ok(Box::new(screen))
+        }
     }
 }
 


### PR DESCRIPTION
This addresses some of #148. 

Notably:

- Mouse support is now disabled by default
- You can enable mouse support by passing `-M` or `--mouse` when starting the app. (temporarily)

I think it's probably better for this setting to live in your `*.lua` config scripts so that you can make it permanent and keep it under version control, but I wanted to take a stab at this and get it in motion.

@LiquidityC Any guidance on what the config option should be? 
