### PR TITLE
Exit process on panic

### DIFF
--- a/src/tools/crash_handler.rs
+++ b/src/tools/crash_handler.rs
@@ -49,5 +49,6 @@ pub fn register_panic_hook() {
         .for_each(|line| print!("{}\r\n", line));
 
         println!("\x1b[0m");
+        std::process::exit(1);
     }));
 }


### PR DESCRIPTION
I really like the friendly screen that displays when a panic happens, but a few times I've noticed that my terminal gets hung and won't let me quit to a shell after a panic.

I believe this is because Rust's `panic()` is local to the thread, so when a child thread panics the main thread keeps running. In our case it means the input thread can die and display the panic screen while the rest of the program invisibly keeps running.

Just calling `exit(1)` in the crash handler seems to be a simple fix.
