### PR TITLE
Enables Lua's `debug` library.

### DIFF
--- a/src/lua/lua_script.rs
+++ b/src/lua/lua_script.rs
@@ -18,7 +18,7 @@ fn create_default_lua_state(
     dimensions: (u16, u16),
     core: Option<Core>,
 ) -> Lua {
-    let state = Lua::new();
+    let state = unsafe { Lua::new_with_debug() };
 
     let mut blight = Blight::new(writer.clone());
     let core = match core {


### PR DESCRIPTION
This is a take on #154. With this PR, you can use Lua's [`debug`](https://www.lua.org/pil/23.html) module in Blightmud.

It requires an `unsafe` call because you can use it in a way that causes the dreaded _Undefined Behavior_ 🎃. I think that's acceptable since this library is already a "power user" API, but wanted to highlight it in case it's not okay.

(Something else to note: rlua's creator [believes](https://github.com/amethyst/rlua/issues/192) that even regular `rlua::Lua::new()` should be `unsafe` at this point because you can cause UB by doing things like loading bytecode or DLLs.)

In action:

```
> /lua function bam() blight:output(debug.traceback()) end
> /lua bam()
stack traceback:
	[string "function bam() blight:output(debug.traceback()) end"]:1: in function 'bam'
	(...tail calls...)
	[string "?"]:22: in function <[string "?"]:10>
> /lua function test() bam() end
> /lua test()
stack traceback:
	[string "function bam() blight:output(debug.traceback()) end"]:1: in function 'bam'
	[string "function test() bam() end"]:1: in function 'test'
	(...tail calls...)
	[string "?"]:22: in function <[string "?"]:10>
```

And all the gorey details:

```
> /lua debug
{
  traceback = "function: 0x103a24f70",
  setupvalue = "function: 0x103a24ee0",
  getuservalue = "function: 0x103a24030",
  setmetatable = "function: 0x103a24e80",
  upvalueid = "function: 0x103a24a20",
  gethook = "function: 0x103a24070",
  getinfo = "function: 0x103a241f0",
  debug = "function: 0x103a23ea0",
  setuservalue = "function: 0x103a24aa0",
  sethook = "function: 0x103a24af0",
  setlocal = "function: 0x103a24d10",
  upvaluejoin = "function: 0x103a24910",
  getupvalue = "function: 0x103a24890",
  getmetatable = "function: 0x103a24850",
  getlocal = "function: 0x103a24690",
  getregistry = "function: 0x103a24830"
}
```

Checking out a builtin:

```
> /lua debug.getinfo(print)
{
  linedefined = -1,
  nups = 0,
  source = "=[C]",
  what = "C",
  func = "function: 0x103a20550",
  istailcall = false,
  isvararg = true,
  short_src = "[C]",
  currentline = -1,
  namewhat = "",
  lastlinedefined = -1,
  nparams = 0
}
```

Should I add docs too? 
