### PR TITLE
Allows new settings

### DIFF
--- a/src/model/settings.rs
+++ b/src/model/settings.rs
@@ -11,27 +11,23 @@ pub struct Settings {
 
 pub const LOGGING_ENABLED: &str = "logging_enabled";
 pub const TTS_ENABLED: &str = "tts_enabled";
+pub const SETTINGS: [&str; 2] = [LOGGING_ENABLED, TTS_ENABLED];
 
 impl Settings {
     pub fn get(&self, key: &str) -> Result<bool> {
-        if let Some(value) = self.settings.get(key) {
-            Ok(*value)
+        if SETTINGS.contains(&key) {
+            Ok(*self.settings.get(key).unwrap_or(&false))
         } else {
             bail!("Unknown setting: {}", key)
         }
     }
 
     pub fn set(&mut self, key: &str, value: bool) -> Result<()> {
-        match key {
-            LOGGING_ENABLED => {
-                self.settings.insert(key.to_string(), value);
-                Ok(())
-            }
-            TTS_ENABLED => {
-                self.settings.insert(key.to_string(), value);
-                Ok(())
-            }
-            _ => bail!("Unknown setting: {}", key),
+        if SETTINGS.contains(&key) {
+            self.settings.insert(key.to_string(), value);
+            Ok(())
+        } else {
+            bail!("Unknown setting: {}", key)
         }
     }
 }

--- a/src/model/settings.rs
+++ b/src/model/settings.rs
@@ -46,3 +46,49 @@ impl SaveData for Settings {
         crate::DATA_DIR.join("config").join("settings.ron")
     }
 }
+
+#[cfg(test)]
+mod settings_test {
+    use super::*;
+
+    #[test]
+    fn get_settings() {
+        let settings = Settings::default();
+
+        assert_eq!(true, settings.get(TTS_ENABLED).unwrap());
+        assert_eq!(false, settings.get(LOGGING_ENABLED).unwrap());
+        assert_eq!(
+            "Unknown setting: SOMETHING_RANDOM",
+            settings.get("SOMETHING_RANDOM").unwrap_err().to_string()
+        );
+    }
+
+    #[test]
+    fn new_settings() {
+        let map = HashMap::new();
+        let settings = Settings { settings: map };
+        assert_eq!(false, settings.get(TTS_ENABLED).unwrap());
+        assert_eq!(
+            "Unknown setting: SOMETHING_RANDOM",
+            settings.get("SOMETHING_RANDOM").unwrap_err().to_string()
+        );
+    }
+
+    #[test]
+    fn set_settings() {
+        let mut settings = Settings::default();
+
+        settings.set(TTS_ENABLED, false).unwrap();
+        settings.set(LOGGING_ENABLED, true).unwrap();
+
+        assert_eq!(false, settings.get(TTS_ENABLED).unwrap());
+        assert_eq!(true, settings.get(LOGGING_ENABLED).unwrap());
+        assert_eq!(
+            "Unknown setting: SOMETHING_RANDOM",
+            settings
+                .set("SOMETHING_RANDOM", true)
+                .unwrap_err()
+                .to_string()
+        );
+    }
+}


### PR DESCRIPTION
As far as I can tell, it's currently difficult to add new settings to existing installations of Blightmud because calling `settings.get()` with any key that does not appear in the `settings.toml` file will error, even if you've otherwise added the setting to all the right places in the code.

You can add a new setting to `Settings::default()`, but that's only used when there's no existing `settings.toml`.

This PR adds a list of known settings and checks against them before erroring, defaulting to `false` if one doesn't appear in `settings.toml`.

This doesn't address the "defaults" issue, however - any new settings added to `Settings::default()` will still be ignored when the TOML file already exists.
