### PR TITLE
Attempt to stop bold from "bleeding" into other lines

### DIFF
--- a/resources/help/lua_colors.md
+++ b/resources/help/lua_colors.md
@@ -6,6 +6,7 @@ mudding. The following colors are available:
 ## Foreground colors
 
 - `C_RESET`
+- `C_BOLD`
 - `C_BLACK`
 - `C_RED`
 - `C_GREEN`

--- a/resources/lua/defaults.lua
+++ b/resources/lua/defaults.lua
@@ -1,5 +1,6 @@
 -- Colors
 C_RESET = "\x1b[0m"
+C_BOLD = "\x1b[1m"
 C_BLACK = "\x1b[30m"
 C_RED = "\x1b[31m"
 C_GREEN = "\x1b[32m"

--- a/src/ui/screen.rs
+++ b/src/ui/screen.rs
@@ -17,7 +17,7 @@ struct TerminalSizeError;
 
 impl fmt::Display for TerminalSizeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Failed to retrieve valid dimsensions for terminal")
+        write!(f, "Failed to retrieve valid dimensions for terminal")
     }
 }
 
@@ -84,9 +84,10 @@ impl StatusArea {
         for line in self.start_line..self.end_line + 1 {
             write!(
                 screen,
-                "{}{}",
+                "{}{}{}",
                 termion::cursor::Goto(1, line),
                 termion::clear::CurrentLine,
+                termion::style::Reset,
             )?;
         }
 
@@ -425,7 +426,8 @@ impl Screen {
         if let Some(line) = send.print_line() {
             self.tts_ctrl.lock().unwrap().speak_input(&line);
             self.print_line(&format!(
-                "{}> {}{}",
+                "{}{}> {}{}",
+                termion::style::Reset,
                 color::Fg(color::LightYellow),
                 line,
                 color::Fg(color::Reset)
@@ -487,9 +489,10 @@ impl Screen {
             let line_no = OUTPUT_START_LINE + i;
             write!(
                 self.screen,
-                "{}{}{}",
+                "{}{}{}{}",
                 termion::cursor::Goto(1, line_no),
                 termion::clear::CurrentLine,
+                termion::style::Reset,
                 self.history.inner[index],
             )?;
         }


### PR DESCRIPTION
This is a potential fix for #140. 

While digging in, I noticed that not only does bold styling bleed into the status area when you scroll the buffer, it also seems to bleed into subsequent output lines:

| bold bleed | no bleed |
| --- | --- |
| ![bold bleed](https://user-images.githubusercontent.com/41523880/97792227-d9eb7d80-1b98-11eb-8117-8d2ec5d338e4.png) | ![no bleed](https://user-images.githubusercontent.com/41523880/97792266-6007c400-1b99-11eb-87e1-1c43f01aa590.png) |

This is sort of a "brute force" fix as I disabled the bold styling manually in a few different places.

I also snuck in a `C_BOLD` Lua constant...
