### PR TITLE
Add `cformat` utility for easy text formatting

### DIFF
--- a/resources/help/lua_colors.md
+++ b/resources/help/lua_colors.md
@@ -15,7 +15,7 @@ mudding. The following colors are available:
 - `C_MAGENTA`
 - `C_CYAN`
 - `C_WHITE`
-             
+
 ## Background colors
 
 - `BG_BLACK`
@@ -28,7 +28,7 @@ mudding. The following colors are available:
 - `BG_WHITE`
 
 ## Bright foreground colors
-             
+
 - `C_BBLACK`
 - `C_BRED`
 - `C_BGREEN`
@@ -39,7 +39,7 @@ mudding. The following colors are available:
 - `C_BWHITE`
 
 ## Bright background colors
-             
+
 - `BG_BBLACK`
 - `BG_BRED`
 - `BG_BGREEN`
@@ -73,3 +73,15 @@ blight:output(C_INFO .. "Ok, he left. Everbody relax!" .. C_RESET)
 ```
 
 There is a lot more you can do with ansi escapes in a terminal. All your ideas should probably work through `blight:output(msg)`
+
+## cformat utility
+
+Concatenating variables everywhere isn't the best coding experience. That's
+why we provide the `cformat` utility function, which will return a formatted
+string you can use.
+
+```lua
+blight:output(cformat('This is some <red>red<reset> text.'))
+blight:output(cformat('This is some <red:blue>red on blue<reset> text.'))
+blight:output(cformat('This is some <yellow>%s<reset> text.', 'formatted'))
+```

--- a/resources/lua/functions.lua
+++ b/resources/lua/functions.lua
@@ -11,3 +11,16 @@ end
 function _G.print(...)
 	blight:output(...)
 end
+
+function cformat(msg, ...)
+  msg = msg:gsub("<(.-)>", function (s)
+    if s:find(':', 1, true) then
+      local fg, bg = s:match('(%w+):(%w+)')
+      return _G['C_' .. fg:upper()] .. _G['BG_' .. bg:upper()]
+    else
+      return _G['C_' .. s:upper()]
+    end
+	end)
+
+	return msg:format(...)
+end

--- a/resources/lua/functions.lua
+++ b/resources/lua/functions.lua
@@ -20,7 +20,7 @@ function cformat(msg, ...)
     else
       return _G['C_' .. s:upper()]
     end
-	end)
+  end)
 
-	return msg:format(...)
+  return msg:format(...)
 end


### PR DESCRIPTION
This adds a new Lua function to handle easy formatting of text.

See documentation for examples.