### PR TITLE
Disables mouse setting by default

### DIFF
--- a/src/model/settings.rs
+++ b/src/model/settings.rs
@@ -38,7 +38,7 @@ impl Default for Settings {
         let mut settings: HashMap<String, bool> = HashMap::new();
         settings.insert(LOGGING_ENABLED.to_string(), false);
         settings.insert(TTS_ENABLED.to_string(), true);
-        settings.insert(MOUSE_ENABLED.to_string(), true);
+        settings.insert(MOUSE_ENABLED.to_string(), false);
         Self { settings }
     }
 }


### PR DESCRIPTION
Small thing, but the mouse setting should be disabled by default. I must have had it turned on while testing. This PR disables it again.