### PR TITLE
Changes macOS config dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,18 +55,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1fd36ffbb1fb7c834eac128ea8d0e310c5aeb635548f9d58861e1308d46e71c"
 
 [[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,24 +147,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "blake2b_simd"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
-
-[[package]]
 name = "blightmud"
 version = "2.3.0"
 dependencies = [
  "anyhow",
  "chrono",
  "curl",
- "dirs-next",
  "flate2",
  "getopts",
  "human-panic",
@@ -192,7 +168,6 @@ dependencies = [
  "rs-complete",
  "serde",
  "serde_json",
- "shellexpand",
  "signal-hook",
  "simple-error",
  "simple-logging",
@@ -330,12 +305,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce90df4c658c62f12d78f7508cf92f9173e5184a539c10bfe54a3107b3ffd0f2"
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
 name = "core-foundation"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,7 +364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -406,7 +375,7 @@ checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -417,21 +386,10 @@ checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
 dependencies = [
  "cfg-if 1.0.0",
  "const_fn",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
  "lazy_static",
  "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "lazy_static",
 ]
 
 [[package]]
@@ -484,48 +442,6 @@ checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
 dependencies = [
  "adler32",
  "byteorder",
-]
-
-[[package]]
-name = "dirs"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
-dependencies = [
- "cfg-if 0.1.10",
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if 1.0.0",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99de365f605554ae33f115102a02057d4fc18b01f3284d6870be0938743cfe7d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -1230,7 +1146,7 @@ checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
  "lazy_static",
  "num_cpus",
 ]
@@ -1248,17 +1164,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 dependencies = [
  "redox_syscall",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
-dependencies = [
- "getrandom",
- "redox_syscall",
- "rust-argon2",
 ]
 
 [[package]]
@@ -1319,18 +1224,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1659e60ace9af419b66a89f424ead1022d471fa76caccedf6e3e5690ed2d19f9"
 dependencies = [
  "anyhow",
-]
-
-[[package]]
-name = "rust-argon2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
-dependencies = [
- "base64",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
@@ -1453,15 +1346,6 @@ name = "shell-words"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074"
-
-[[package]]
-name = "shellexpand"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2b22262a9aaf9464d356f656fea420634f78c881c5eebd5ef5e66d8b9bc603"
-dependencies = [
- "dirs",
-]
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,6 @@ simple-error = "0.2.2"
 getopts = "0.2.21"
 curl = "0.4.34"
 human-panic = "1.0.3"
-shellexpand = "2.0.0"
 native-tls = "0.2.4"
 tts = { version = "0.10.1", optional = true }
 serde_json = "1.0.59"
-dirs-next = "2.0.0"

--- a/src/lua/lua_script.rs
+++ b/src/lua/lua_script.rs
@@ -1,10 +1,9 @@
 use super::{alias::Alias, trigger::Trigger, util::*};
-use super::{blight::*, tts::Tts};
+use super::{blight::*, tts::Tts, util::expand_tilde};
 use super::{constants::*, core::Core, ui_event::UiEvent};
 use crate::{event::Event, model::Line};
 use anyhow::Result;
 use rlua::{Lua, Result as LuaResult};
-use shellexpand as shell;
 use std::io::prelude::*;
 use std::{fs::File, sync::mpsc::Sender};
 
@@ -245,7 +244,7 @@ impl LuaScript {
     }
 
     pub fn load_script(&mut self, path: &str) -> Result<()> {
-        let mut file = File::open(shell::tilde(path).as_ref())?;
+        let mut file = File::open(expand_tilde(path).as_ref())?;
         let mut content = String::new();
         file.read_to_string(&mut content)?;
         if let Err(msg) = self

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -11,4 +11,4 @@ mod store_data;
 mod trigger;
 mod tts;
 mod ui_event;
-mod util;
+pub mod util;

--- a/src/lua/util.rs
+++ b/src/lua/util.rs
@@ -14,7 +14,7 @@ pub fn output_stack_trace(writer: &Sender<Event>, error: &str) {
 
 /// "~/blightmud" => "/home/yourname/blightmud"
 pub fn expand_tilde(path: &str) -> Cow<str> {
-    if path.starts_with("~") {
+    if path.starts_with('~') {
         Cow::from(env::var("HOME").expect("$HOME must be set") + &path[1..])
     } else {
         Cow::from(path)
@@ -31,7 +31,10 @@ mod util_tests {
         assert_eq!("/home/what/blightmud", expand_tilde("~/blightmud"));
 
         env::set_var("HOME", "/Users/cindi");
-        assert_eq!("/Users/cindi/blightmud/data", expand_tilde("~/blightmud/data"));
+        assert_eq!(
+            "/Users/cindi/blightmud/data",
+            expand_tilde("~/blightmud/data")
+        );
 
         assert_eq!("/leave/it/alone", expand_tilde("/leave/it/alone"));
         assert_eq!("/leave/~/alone", expand_tilde("/leave/~/alone"));

--- a/src/lua/util.rs
+++ b/src/lua/util.rs
@@ -1,5 +1,5 @@
 use crate::event::Event;
-use std::sync::mpsc::Sender;
+use std::{borrow::Cow, env, sync::mpsc::Sender};
 
 pub fn output_stack_trace(writer: &Sender<Event>, error: &str) {
     writer
@@ -9,5 +9,31 @@ pub fn output_stack_trace(writer: &Sender<Event>, error: &str) {
         writer
             .send(Event::Error(format!("\t{}", line).to_string()))
             .unwrap();
+    }
+}
+
+/// "~/blightmud" => "/home/yourname/blightmud"
+pub fn expand_tilde(path: &str) -> Cow<str> {
+    if path.starts_with("~") {
+        Cow::from(env::var("HOME").expect("$HOME must be set") + &path[1..])
+    } else {
+        Cow::from(path)
+    }
+}
+
+#[cfg(test)]
+mod util_tests {
+    use super::*;
+
+    #[test]
+    fn homedir_expansion() {
+        env::set_var("HOME", "/home/what");
+        assert_eq!("/home/what/blightmud", expand_tilde("~/blightmud"));
+
+        env::set_var("HOME", "/Users/cindi");
+        assert_eq!("/Users/cindi/blightmud/data", expand_tilde("~/blightmud/data"));
+
+        assert_eq!("/leave/it/alone", expand_tilde("/leave/it/alone"));
+        assert_eq!("/leave/~/alone", expand_tilde("/leave/~/alone"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,3 @@
-#[cfg(not(debug_assertions))]
-use dirs_next as dirs;
-
 use lazy_static::lazy_static;
 use libtelnet_rs::events::TelnetEvents;
 use log::{error, info};
@@ -38,14 +35,19 @@ use tools::register_panic_hook;
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const PROJECT_NAME: &str = "Blightmud";
 
+#[cfg(not(debug_assertions))]
+const XDG_DATA_DIR: &str = "~/.local/share/blightmud";
+#[cfg(not(debug_assertions))]
+const XDG_CONFIG_DIR: &str = "~/.config/blightmud";
+
 type TelnetData = Option<Vec<u8>>;
 
 lazy_static! {
     pub static ref DATA_DIR: PathBuf = {
         #[cfg(not(debug_assertions))]
         {
-            let mut data_dir = dirs::data_dir().unwrap();
-            data_dir.push("blightmud");
+            use crate::lua::util;
+            let data_dir = PathBuf::from(util::expand_tilde(XDG_DATA_DIR).as_ref());
             let _ = std::fs::create_dir_all(&data_dir);
             data_dir
         }
@@ -56,8 +58,8 @@ lazy_static! {
     pub static ref CONFIG_DIR: PathBuf = {
         #[cfg(not(debug_assertions))]
         {
-            let mut config_dir = dirs::config_dir().unwrap();
-            config_dir.push("blightmud");
+            use crate::lua::util;
+            let config_dir = PathBuf::from(util::expand_tilde(XDG_CONFIG_DIR).as_ref());
             let _ = std::fs::create_dir_all(&config_dir);
             config_dir
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,15 +46,11 @@ lazy_static! {
     pub static ref DATA_DIR: PathBuf = {
         #[cfg(not(debug_assertions))]
         {
-            use crate::lua::util;
-            let mut data_dir = PathBuf::from(util::expand_tilde(XDG_DATA_DIR).as_ref());
-
-            #[cfg(target_os = "macos")]
-            {
-                if MACOS_DEPRECATED_DIR.exists() {
-                    data_dir = MACOS_DEPRECATED_DIR.to_path_buf();
-                }
-            }
+            let data_dir = if cfg!(target_os = "macos") && MACOS_DEPRECATED_DIR.exists() {
+                MACOS_DEPRECATED_DIR.to_path_buf();
+            } else {
+                PathBuf::from(crate::lua::util::expand_tilde(XDG_DATA_DIR).as_ref())
+            };
 
             let _ = std::fs::create_dir_all(&data_dir);
             data_dir
@@ -66,15 +62,12 @@ lazy_static! {
     pub static ref CONFIG_DIR: PathBuf = {
         #[cfg(not(debug_assertions))]
         {
-            use crate::lua::util;
-            let mut config_dir = PathBuf::from(util::expand_tilde(XDG_CONFIG_DIR).as_ref());
 
-            #[cfg(target_os = "macos")]
-            {
-                if MACOS_DEPRECATED_DIR.exists() {
-                    config_dir = MACOS_DEPRECATED_DIR.to_path_buf();
-                }
-            }
+            let config_dir = if cfg!(target_os = "macos") && MACOS_DEPRECATED_DIR.exists() {
+                MACOS_DEPRECATED_DIR.to_path_buf();
+            } else {
+                PathBuf::from(crate::lua::util::expand_tilde(XDG_CONFIG_DIR).as_ref())
+            };
 
             let _ = std::fs::create_dir_all(&config_dir);
             config_dir
@@ -83,8 +76,6 @@ lazy_static! {
         #[cfg(debug_assertions)]
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
     };
-
-    #[cfg(target_os = "macos")]
     pub static ref MACOS_DEPRECATED_DIR: PathBuf = {
         use crate::lua::util;
         PathBuf::from(util::expand_tilde("~/Library/Application Support/blightmud").as_ref())

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ lazy_static! {
         #[cfg(not(debug_assertions))]
         {
             let data_dir = if cfg!(target_os = "macos") && MACOS_DEPRECATED_DIR.exists() {
-                MACOS_DEPRECATED_DIR.to_path_buf();
+                MACOS_DEPRECATED_DIR.to_path_buf()
             } else {
                 PathBuf::from(crate::lua::util::expand_tilde(XDG_DATA_DIR).as_ref())
             };
@@ -62,9 +62,8 @@ lazy_static! {
     pub static ref CONFIG_DIR: PathBuf = {
         #[cfg(not(debug_assertions))]
         {
-
             let config_dir = if cfg!(target_os = "macos") && MACOS_DEPRECATED_DIR.exists() {
-                MACOS_DEPRECATED_DIR.to_path_buf();
+                MACOS_DEPRECATED_DIR.to_path_buf()
             } else {
                 PathBuf::from(crate::lua::util::expand_tilde(XDG_CONFIG_DIR).as_ref())
             };


### PR DESCRIPTION
This is a follow-up to #173. It changes the default macOS config dir and data dir from `~/Library/Application Support` to `~/.config` and `~/.local/share` respectively, but if it finds the `Library` directory it uses it and prints a deprecation notice.

@LiquidityC's list:

- [x] Drop dirs-next and shellexpand crates and add our own handling
- [x] On start we check if ~/Library/Application Support/blightmud exists. If it does then use that as config dir and show a warning.
- [x] Default all config and data paths to $HOME. This is currently .config and .local

Not totally sure about sticking the deprecation message right into the function like that but didn't want to get too fancy for a temporary fix. Any suggestions?

It looks like this:

![image](https://user-images.githubusercontent.com/41523880/98045395-54a4da80-1ddd-11eb-8495-b6038d84cb9e.png)
