### PR TITLE
Removes `terminate` in favor of Event::Quit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,7 @@ use lazy_static::lazy_static;
 use libtelnet_rs::events::TelnetEvents;
 use log::{error, info};
 use std::path::PathBuf;
-use std::sync::{
-    atomic::Ordering,
-    mpsc::{channel, Receiver, Sender},
-};
+use std::sync::mpsc::{channel, Receiver, Sender};
 use std::{env, fs, thread};
 use ui::HelpHandler;
 
@@ -280,200 +277,190 @@ For more info: https://github.com/LiquidityC/Blightmud/issues/173"#;
         }
     }
 
-    loop {
-        if session.terminate.load(Ordering::Relaxed) {
-            break;
-        }
-        if let Ok(event) = main_thread_read.recv() {
-            match event {
-                Event::ServerSend(_)
-                | Event::ServerInput(_)
-                | Event::Connect(_)
-                | Event::Connected
-                | Event::Reconnect
-                | Event::Disconnect(_) => {
-                    event_handler.handle_server_events(event, &mut screen, &mut transmit_writer)?;
-                }
-                Event::AddServer(_, _)
-                | Event::RemoveServer(_)
-                | Event::LoadServer(_)
-                | Event::ListServers => {
-                    event_handler.handle_store_events(event, &mut saved_servers, &mut screen)?;
-                }
-                Event::MudOutput(_)
-                | Event::Output(_)
-                | Event::Prompt
-                | Event::Error(_)
-                | Event::Info(_)
-                | Event::InputSent(_)
-                | Event::UserInputBuffer(_, _) => {
-                    //tts_ctrl.handle_events(event.clone());
-                    event_handler.handle_output_events(event, &mut screen)?;
-                }
+    while let Ok(event) = main_thread_read.recv() {
+        match event {
+            Event::ServerSend(_)
+            | Event::ServerInput(_)
+            | Event::Connect(_)
+            | Event::Connected
+            | Event::Reconnect
+            | Event::Disconnect(_) => {
+                event_handler.handle_server_events(event, &mut screen, &mut transmit_writer)?;
+            }
+            Event::AddServer(_, _)
+            | Event::RemoveServer(_)
+            | Event::LoadServer(_)
+            | Event::ListServers => {
+                event_handler.handle_store_events(event, &mut saved_servers, &mut screen)?;
+            }
+            Event::MudOutput(_)
+            | Event::Output(_)
+            | Event::Prompt
+            | Event::Error(_)
+            | Event::Info(_)
+            | Event::InputSent(_)
+            | Event::UserInputBuffer(_, _) => {
+                //tts_ctrl.handle_events(event.clone());
+                event_handler.handle_output_events(event, &mut screen)?;
+            }
 
-                Event::TTSEnabled(enabled) => session.tts_ctrl.lock().unwrap().enabled(enabled),
-                Event::Speak(msg, interupt) => {
-                    session.tts_ctrl.lock().unwrap().speak(&msg, interupt)
-                }
-                Event::SpeakStop => session.tts_ctrl.lock().unwrap().flush(),
-                Event::TTSEvent(event) => session.tts_ctrl.lock().unwrap().handle(event),
+            Event::TTSEnabled(enabled) => session.tts_ctrl.lock().unwrap().enabled(enabled),
+            Event::Speak(msg, interupt) => session.tts_ctrl.lock().unwrap().speak(&msg, interupt),
+            Event::SpeakStop => session.tts_ctrl.lock().unwrap().flush(),
+            Event::TTSEvent(event) => session.tts_ctrl.lock().unwrap().handle(event),
 
-                Event::ShowSettings => SETTINGS.iter().for_each(|key| {
-                    screen.print_info(&format!("{} => {}", key, settings.get(key).unwrap()));
-                }),
-                Event::ShowSetting(setting) => match settings.get(&setting) {
-                    Ok(value) => screen.print_info(&format!("Setting: {} => {}", setting, value)),
-                    Err(error) => screen.print_error(&error.to_string()),
-                },
-                Event::ToggleSetting(setting, toggle) => {
-                    let toggle = matches!(toggle.as_str(), "on" | "true" | "enabled");
-                    if let Err(error) = settings.set(&setting, toggle) {
-                        screen.print_error(&error.to_string());
-                    } else {
-                        if setting == SAVE_HISTORY {
-                            session.set_save_history(toggle);
-                        }
-                        screen.print_info(&format!("Setting: {} => {}", setting, toggle));
+            Event::ShowSettings => SETTINGS.iter().for_each(|key| {
+                screen.print_info(&format!("{} => {}", key, settings.get(key).unwrap()));
+            }),
+            Event::ShowSetting(setting) => match settings.get(&setting) {
+                Ok(value) => screen.print_info(&format!("Setting: {} => {}", setting, value)),
+                Err(error) => screen.print_error(&error.to_string()),
+            },
+            Event::ToggleSetting(setting, toggle) => {
+                let toggle = matches!(toggle.as_str(), "on" | "true" | "enabled");
+                if let Err(error) = settings.set(&setting, toggle) {
+                    screen.print_error(&error.to_string());
+                } else {
+                    if setting == SAVE_HISTORY {
+                        session.set_save_history(toggle);
                     }
+                    screen.print_info(&format!("Setting: {} => {}", setting, toggle));
                 }
-                Event::StartLogging(world, force) => {
-                    if settings.get(LOGGING_ENABLED)? || force {
-                        screen.print_info(&format!("Started logging for: {}", world));
-                        session.start_logging(&world)
-                    }
+            }
+            Event::StartLogging(world, force) => {
+                if settings.get(LOGGING_ENABLED)? || force {
+                    screen.print_info(&format!("Started logging for: {}", world));
+                    session.start_logging(&world)
                 }
-                Event::StopLogging => {
-                    screen.print_info("Logging stopped");
-                    session.stop_logging();
-                }
-                Event::EnableProto(proto) => {
-                    if let Ok(mut parser) = session.telnet_parser.lock() {
-                        parser.options.support(proto);
-                        if session.connected() {
-                            if let Some(TelnetEvents::DataSend(data)) = parser._do(proto) {
-                                session.main_writer.send(Event::ServerSend(data)).unwrap();
-                            }
-                        }
-                    }
-                }
-                Event::DisableProto(proto) => {
-                    if let Ok(mut parser) = session.telnet_parser.lock() {
-                        let mut opt = parser.options.get_option(proto);
-                        opt.local = false;
-                        opt.remote = false;
-                        parser.options.set_option(proto, opt);
-                        if session.connected() {
-                            if let Some(TelnetEvents::DataSend(data)) = parser._dont(proto) {
-                                session.main_writer.send(Event::ServerSend(data)).unwrap();
-                            }
-                        }
-                    }
-                }
-                Event::ProtoEnabled(proto) => {
-                    if let Ok(mut lua) = session.lua_script.lock() {
-                        lua.proto_enabled(proto);
-                        lua.get_output_lines().iter().for_each(|l| {
-                            screen.print_output(l);
-                        });
-                    }
-                }
-                Event::ProtoSubnegRecv(proto, data) => {
-                    if let Ok(mut script) = session.lua_script.lock() {
-                        script.proto_subneg(proto, &data);
-                        script.get_output_lines().iter().for_each(|l| {
-                            screen.print_output(l);
-                        });
-                    }
-                }
-                Event::ProtoSubnegSend(proto, data) => {
-                    if let Ok(mut parser) = session.telnet_parser.lock() {
-                        if let Some(TelnetEvents::DataSend(data)) =
-                            parser.subnegotiation(proto, data)
-                        {
+            }
+            Event::StopLogging => {
+                screen.print_info("Logging stopped");
+                session.stop_logging();
+            }
+            Event::EnableProto(proto) => {
+                if let Ok(mut parser) = session.telnet_parser.lock() {
+                    parser.options.support(proto);
+                    if session.connected() {
+                        if let Some(TelnetEvents::DataSend(data)) = parser._do(proto) {
                             session.main_writer.send(Event::ServerSend(data)).unwrap();
                         }
                     }
                 }
-                Event::ScrollUp => screen.scroll_up()?,
-                Event::ScrollDown => screen.scroll_down()?,
-                Event::ScrollTop => screen.scroll_top()?,
-                Event::ScrollBottom => screen.reset_scroll()?,
-                Event::StatusAreaHeight(height) => screen.set_status_area_height(height)?,
-                Event::StatusLine(index, info) => screen.set_status_line(index, info)?,
-                Event::LoadScript(path) => {
-                    info!("Loading script: {}", path);
-                    let mut lua = session.lua_script.lock().unwrap();
-                    if let Err(err) = lua.load_script(&path) {
-                        screen.print_error(&format!("Failed to load file: {}", err));
-                    } else {
-                        screen.print_info(&format!("Loaded script: {}", path));
-                        lua.get_output_lines().iter().for_each(|l| {
-                            screen.print_output(l);
-                        });
-                    }
-                }
-                Event::ResetScript => {
-                    info!("Clearing scripts");
-                    screen.print_info("Clearing scripts...");
-                    if let Ok(mut script) = session.lua_script.lock() {
-                        script.reset((screen.width, screen.height));
-                        screen.print_info("Done");
-                    }
-                    session.timer_writer.send(TimerEvent::Clear)?;
-                }
-                Event::ShowHelp(hfile) => {
-                    help_handler.show_help(&hfile)?;
-                }
-                Event::AddTimedEvent(duration, count, id) => {
-                    session
-                        .timer_writer
-                        .send(TimerEvent::Create(duration, count, id))?;
-                }
-                Event::TimedEvent(id) => {
-                    if let Ok(mut script) = session.lua_script.lock() {
-                        script.run_timed_function(id);
-                        script.get_output_lines().iter().for_each(|l| {
-                            screen.print_output(l);
-                        });
-                    }
-                }
-                Event::DropTimedEvent(id) => {
-                    session.lua_script.lock().unwrap().remove_timed_function(id);
-                }
-                Event::ClearTimers => {
-                    session.timer_writer.send(TimerEvent::Clear)?;
-                }
-                Event::RemoveTimer(idx) => {
-                    session.timer_writer.send(TimerEvent::Remove(idx))?;
-                }
-                Event::Redraw => {
-                    screen.setup()?;
-                    if let Ok(mut script) = session.lua_script.lock() {
-                        script.set_dimensions((screen.width, screen.height));
-                    }
-                    let prompt_input = session.prompt_input.lock().unwrap();
-                    screen.print_prompt_input(&prompt_input, prompt_input.len());
-                }
-                Event::Quit => {
-                    if settings.get(CONFIRM_QUIT)? {
-                        screen.print_info("Confirm quit with ctrl-c");
-                        screen.flush();
-                        let _ = main_thread_read.recv()?; // skip UserInputBuffer event
-                        match main_thread_read.recv()? {
-                            Event::Quit => {}
-                            e => {
-                                session.main_writer.send(e).unwrap();
-                                continue;
-                            }
+            }
+            Event::DisableProto(proto) => {
+                if let Ok(mut parser) = session.telnet_parser.lock() {
+                    let mut opt = parser.options.get_option(proto);
+                    opt.local = false;
+                    opt.remote = false;
+                    parser.options.set_option(proto, opt);
+                    if session.connected() {
+                        if let Some(TelnetEvents::DataSend(data)) = parser._dont(proto) {
+                            session.main_writer.send(Event::ServerSend(data)).unwrap();
                         }
                     }
-                    session.terminate.store(true, Ordering::Relaxed);
-                    session.disconnect();
-                    break;
                 }
-            };
-            screen.flush();
-        }
+            }
+            Event::ProtoEnabled(proto) => {
+                if let Ok(mut lua) = session.lua_script.lock() {
+                    lua.proto_enabled(proto);
+                    lua.get_output_lines().iter().for_each(|l| {
+                        screen.print_output(l);
+                    });
+                }
+            }
+            Event::ProtoSubnegRecv(proto, data) => {
+                if let Ok(mut script) = session.lua_script.lock() {
+                    script.proto_subneg(proto, &data);
+                    script.get_output_lines().iter().for_each(|l| {
+                        screen.print_output(l);
+                    });
+                }
+            }
+            Event::ProtoSubnegSend(proto, data) => {
+                if let Ok(mut parser) = session.telnet_parser.lock() {
+                    if let Some(TelnetEvents::DataSend(data)) = parser.subnegotiation(proto, data) {
+                        session.main_writer.send(Event::ServerSend(data)).unwrap();
+                    }
+                }
+            }
+            Event::ScrollUp => screen.scroll_up()?,
+            Event::ScrollDown => screen.scroll_down()?,
+            Event::ScrollTop => screen.scroll_top()?,
+            Event::ScrollBottom => screen.reset_scroll()?,
+            Event::StatusAreaHeight(height) => screen.set_status_area_height(height)?,
+            Event::StatusLine(index, info) => screen.set_status_line(index, info)?,
+            Event::LoadScript(path) => {
+                info!("Loading script: {}", path);
+                let mut lua = session.lua_script.lock().unwrap();
+                if let Err(err) = lua.load_script(&path) {
+                    screen.print_error(&format!("Failed to load file: {}", err));
+                } else {
+                    screen.print_info(&format!("Loaded script: {}", path));
+                    lua.get_output_lines().iter().for_each(|l| {
+                        screen.print_output(l);
+                    });
+                }
+            }
+            Event::ResetScript => {
+                info!("Clearing scripts");
+                screen.print_info("Clearing scripts...");
+                if let Ok(mut script) = session.lua_script.lock() {
+                    script.reset((screen.width, screen.height));
+                    screen.print_info("Done");
+                }
+                session.timer_writer.send(TimerEvent::Clear)?;
+            }
+            Event::ShowHelp(hfile) => {
+                help_handler.show_help(&hfile)?;
+            }
+            Event::AddTimedEvent(duration, count, id) => {
+                session
+                    .timer_writer
+                    .send(TimerEvent::Create(duration, count, id))?;
+            }
+            Event::TimedEvent(id) => {
+                if let Ok(mut script) = session.lua_script.lock() {
+                    script.run_timed_function(id);
+                    script.get_output_lines().iter().for_each(|l| {
+                        screen.print_output(l);
+                    });
+                }
+            }
+            Event::DropTimedEvent(id) => {
+                session.lua_script.lock().unwrap().remove_timed_function(id);
+            }
+            Event::ClearTimers => {
+                session.timer_writer.send(TimerEvent::Clear)?;
+            }
+            Event::RemoveTimer(idx) => {
+                session.timer_writer.send(TimerEvent::Remove(idx))?;
+            }
+            Event::Redraw => {
+                screen.setup()?;
+                if let Ok(mut script) = session.lua_script.lock() {
+                    script.set_dimensions((screen.width, screen.height));
+                }
+                let prompt_input = session.prompt_input.lock().unwrap();
+                screen.print_prompt_input(&prompt_input, prompt_input.len());
+            }
+            Event::Quit => {
+                if settings.get(CONFIRM_QUIT)? {
+                    screen.print_info("Confirm quit with ctrl-c");
+                    screen.flush();
+                    let _ = main_thread_read.recv()?; // skip UserInputBuffer event
+                    match main_thread_read.recv()? {
+                        Event::Quit => {}
+                        e => {
+                            session.main_writer.send(e).unwrap();
+                            continue;
+                        }
+                    }
+                }
+                session.disconnect();
+                break;
+            }
+        };
+        screen.flush();
     }
     screen.reset()?;
     settings.save();

--- a/src/session.rs
+++ b/src/session.rs
@@ -23,7 +23,6 @@ pub struct Session {
     pub gmcp: Arc<AtomicBool>,
     pub main_writer: Sender<Event>,
     pub timer_writer: Sender<TimerEvent>,
-    pub terminate: Arc<AtomicBool>,
     pub telnet_parser: Arc<Mutex<Parser>>,
     pub output_buffer: Arc<Mutex<OutputBuffer>>,
     pub prompt_input: Arc<Mutex<String>>,
@@ -187,7 +186,6 @@ impl SessionBuilder {
             gmcp: Arc::new(AtomicBool::new(false)),
             main_writer: main_writer.clone(),
             timer_writer,
-            terminate: Arc::new(AtomicBool::new(false)),
             telnet_parser: Arc::new(Mutex::new(Parser::with_support_and_capacity(
                 BUFFER_SIZE,
                 build_compatibility_table(),

--- a/src/ui/command.rs
+++ b/src/ui/command.rs
@@ -8,7 +8,7 @@ use std::thread;
 use std::{
     io::stdin,
     path::PathBuf,
-    sync::{atomic::Ordering, mpsc::Sender, Arc, Mutex},
+    sync::{mpsc::Sender, Arc, Mutex},
 };
 use termion::{event::Key, input::TermRead};
 
@@ -411,7 +411,6 @@ pub fn spawn_input_thread(session: Session, saved_servers: Vec<String>) -> threa
     thread::spawn(move || {
         debug!("Input stream spawned");
         let writer = session.main_writer.clone();
-        let terminate = session.terminate.clone();
         let script = session.lua_script.clone();
         let stdin = stdin();
         let mut tts_ctrl = session.tts_ctrl.clone();
@@ -458,9 +457,6 @@ pub fn spawn_input_thread(session: Session, saved_servers: Vec<String>) -> threa
                             .unwrap();
                     }
                 }
-            }
-            if terminate.load(Ordering::Relaxed) {
-                break;
             }
         }
         if session.save_history() {


### PR DESCRIPTION
Something I noticed when messing with `ctrl-c` is that if we can make everything send `Event::Quit` to the main thread, we probably don't need to use the session's `terminate` boolean anymore, unless there are future plans for it or something I'm overlooking. All the child threads will get killed when the main thread exits, unless we `join()` on them somewhere, which we're not at this point. As a bonus it also knocks off a level of indentation in the big loop in `main.rs`.