### PR TITLE
Realtime logging

### DIFF
--- a/src/io/logger.rs
+++ b/src/io/logger.rs
@@ -11,16 +11,8 @@ pub struct Logger {
     file: Option<BufWriter<StripWriter<File>>>,
 }
 
-#[cfg(not(test))]
 fn get_and_ensure_log_dir(host: &str) -> Result<std::path::PathBuf> {
     let path = crate::DATA_DIR.clone().join("logs").join(host);
-    std::fs::create_dir_all(&path).ok();
-    Ok(path)
-}
-
-#[cfg(test)]
-fn get_and_ensure_log_dir(host: &str) -> Result<std::path::PathBuf> {
-    let path = std::path::PathBuf::from("logs").join(host);
     std::fs::create_dir_all(&path).ok();
     Ok(path)
 }

--- a/src/io/logger.rs
+++ b/src/io/logger.rs
@@ -34,6 +34,7 @@ impl Logger {
             if !line.ends_with('\n') {
                 writer.write_all(b"\n")?;
             }
+            writer.flush()?;
             self.file = Some(writer);
         }
         Ok(())

--- a/src/tts/text_to_speech.rs
+++ b/src/tts/text_to_speech.rs
@@ -326,7 +326,8 @@ fn spawn_tts_thread() -> Option<Sender<TTSEvent>> {
                     }
                 }
                 Err(err) => error!("[TTS]: {}", err.to_string()),
-            }).unwrap();
+            })
+            .unwrap();
         Some(tx)
     } else {
         None


### PR DESCRIPTION
Not a big change, but this means MUD log files will get written to as events occur rather than when you quit the app.

After @LiquidityC blew my mind with https://github.com/LiquidityC/Blightmud/issues/195#issuecomment-723343842 I realized that I could be really lazy and avoid writing any Lua at all if Blightmud wrote to its logfile in realtime. As in, you can just do a `tail -f | grep` on the logfile for simple patterns. Or write entire programs that watch the logfile looking for patterns and doing stuff when it finds them... 

