### PR TITLE
Adds test_lua!(), assert_lua!(), and other helpers

### DIFF
--- a/src/lua/line.rs
+++ b/src/lua/line.rs
@@ -71,27 +71,16 @@ impl UserData for Line {
 
 #[cfg(test)]
 mod test_lua_line {
-    use rlua::Lua;
-
     use super::Line;
     use crate::model::Line as mLine;
 
-    fn get_lua() -> Lua {
-        let state = Lua::new();
-        state.context(|ctx| {
-            ctx.globals()
-                .set(
-                    "test_line",
-                    Line::from(mLine::from("\x1b[31mA testing line\x1b[0m")),
-                )
-                .unwrap();
-        });
-        state
+    fn test_line() -> Line {
+        Line::from(mLine::from("\x1b[31mA testing line\x1b[0m"))
     }
 
     #[test]
     fn test_content() {
-        test_lua!();
+        test_lua!("test_line" => test_line());
 
         assert_lua_string!("test_line:line()", "A testing line");
         assert_lua_string!("test_line:raw()", "\x1b[31mA testing line\x1b[0m");
@@ -99,7 +88,7 @@ mod test_lua_line {
 
     #[test]
     fn test_gag() {
-        test_lua!();
+        test_lua!("test_line" => test_line());
 
         assert_lua_bool!("test_line:gag()", false);
         let line: Line = global!("test_line");
@@ -112,7 +101,7 @@ mod test_lua_line {
 
     #[test]
     fn test_tts_gag() {
-        test_lua!();
+        test_lua!("test_line" => test_line());
 
         assert_lua_bool!("test_line:tts_gag()", false);
 
@@ -126,7 +115,7 @@ mod test_lua_line {
 
     #[test]
     fn test_tts_interrupt() {
-        test_lua!();
+        test_lua!("test_line" => test_line());
 
         assert_lua_bool!("test_line:tts_interrupt()", false);
 
@@ -140,7 +129,7 @@ mod test_lua_line {
 
     #[test]
     fn test_skip_log() {
-        test_lua!();
+        test_lua!("test_line" => test_line());
 
         assert_lua_bool!("test_line:skip_log()", false);
         let line: Line = global!("test_line");
@@ -153,7 +142,7 @@ mod test_lua_line {
 
     #[test]
     fn test_matched() {
-        test_lua!();
+        test_lua!("test_line" => test_line());
 
         assert_lua_bool!("test_line:matched()", false);
         let line: Line = global!("test_line");
@@ -166,7 +155,7 @@ mod test_lua_line {
 
     #[test]
     fn test_prompt() {
-        test_lua!();
+        test_lua!("test_line" => test_line());
         assert_lua_bool!("test_line:prompt()", false);
     }
 }

--- a/src/lua/line.rs
+++ b/src/lua/line.rs
@@ -70,7 +70,6 @@ impl UserData for Line {
 }
 
 #[cfg(test)]
-#[allow(unused_macros)]
 mod test_lua_line {
     use rlua::Lua;
 
@@ -88,41 +87,6 @@ mod test_lua_line {
                 .unwrap();
         });
         state
-    }
-
-    macro_rules! test_lua {
-        () => {
-            let state = get_lua();
-
-            macro_rules! assert_lua {
-                ($return_type:ty, $lua_code:literal, $expect:expr) => {
-                    assert_eq!(
-                        state.context(|ctx| -> $return_type {
-                            ctx.load(concat!("return ", $lua_code)).call(()).unwrap()
-                        }),
-                        $expect
-                    );
-                };
-            }
-
-            macro_rules! assert_lua_bool {
-                ($lua_code:literal, $expect:expr) => {
-                    assert_lua!(bool, $lua_code, $expect)
-                };
-            }
-
-            macro_rules! assert_lua_string {
-                ($lua_code:literal, $expect:expr) => {
-                    assert_lua!(String, $lua_code, $expect)
-                };
-            }
-
-            macro_rules! global {
-                ($key:literal) => {
-                    state.context(|ctx| ctx.globals().get($key).unwrap())
-                };
-            }
-        };
     }
 
     #[test]

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -1,6 +1,10 @@
 pub use self::lua_script::LuaScript;
 pub use self::ui_event::UiEvent;
 
+#[cfg(test)]
+#[macro_use]
+mod test_help;
+
 mod alias;
 mod blight;
 mod constants;

--- a/src/lua/test_help.rs
+++ b/src/lua/test_help.rs
@@ -1,0 +1,37 @@
+macro_rules! test_lua {
+    () => {
+        let state = get_lua();
+
+        macro_rules! assert_lua {
+            ($return_type:ty, $lua_code:literal, $expect:expr) => {
+                assert_eq!(
+                    state.context(|ctx| -> $return_type {
+                        ctx.load(concat!("return ", $lua_code)).call(()).unwrap()
+                    }),
+                    $expect
+                );
+            };
+        }
+
+        #[allow(unused_macros)]
+        macro_rules! assert_lua_bool {
+            ($lua_code:literal, $expect:expr) => {
+                assert_lua!(bool, $lua_code, $expect)
+            };
+        }
+
+        #[allow(unused_macros)]
+        macro_rules! assert_lua_string {
+            ($lua_code:literal, $expect:expr) => {
+                assert_lua!(String, $lua_code, $expect)
+            };
+        }
+
+        #[allow(unused_macros)]
+        macro_rules! global {
+            ($key:literal) => {
+                state.context(|ctx| ctx.globals().get($key).unwrap())
+            };
+        }
+    };
+}

--- a/src/lua/test_help.rs
+++ b/src/lua/test_help.rs
@@ -1,6 +1,30 @@
+/// The `test_lua!()` macro should be invoked at the start of a
+/// #[test] function to setup the Lua state and create the following
+/// Lua-specific assertions macros:
+///
+/// * `assert_lua_bool!("true", true);`
+/// * `assert_lua_string!("'Yes'", "Yes");`
+/// * `assert_lua!(usize, "123", 123);`
+///
+/// It also adds two macros for setting and getting globals:
+///
+/// * `let var: TYPE = global!("key");`
+/// * `set_global!("key", "value");`
+///
+/// `test_lua!()` can optionally be called with "key" => value pairs
+/// as a convenience to set globals right away.
 macro_rules! test_lua {
+    // test_lua!(key => value);
+    ($($key:literal => $val:expr),+) => {
+        test_lua!();
+        $( set_global!($key, $val); )+
+    };
+
+    // Allow trailing comma.
+    ($($key:literal => $val:expr,)+) => { test_lua!($($key => $val),+) };
+
     () => {
-        let state = get_lua();
+        let state = rlua::Lua::new();
 
         macro_rules! assert_lua {
             ($return_type:ty, $lua_code:literal, $expect:expr) => {
@@ -31,6 +55,15 @@ macro_rules! test_lua {
         macro_rules! global {
             ($key:literal) => {
                 state.context(|ctx| ctx.globals().get($key).unwrap())
+            };
+        }
+
+        #[allow(unused_macros)]
+        macro_rules! set_global {
+            ($key:literal, $val:expr) => {
+                state.context(|ctx| {
+                    ctx.globals().set($key, $val).unwrap();
+                });
             };
         }
     };


### PR DESCRIPTION
I wanted to see if there's any interest in moving this direction while we're discussing testing Lua code. I've found Rust macros to be super helpful in cleaning up tests and providing little helpers to reduce boilerplate, so I added a few to `line.rs` as a little experiment. They're all generic, so we could pull them out into `test_helper.rs` mod or something if we want to move forward.

But in a nutshell, I've added a macro, `test_lua!()`, that initializes the Lua state by calling `get_lua()` and then adds a few Lua-specific macros to each test function: 

- `assert_lua_string!(code, expected)`
- `assert_lua_bool!(code, expected)`
- `assert_lua!(TYPE, code, expected)`
- `let val: TYPE = global!("key");`

So this:

```rust
let state = get_lua();
assert!(!state
    .context(|ctx| -> bool { ctx.load("return test_line:prompt()").call(()).unwrap() }));
```

becomes this:

```rust
test_lua!();
assert_lua_bool!("test_line:prompt()", false);
```

And this:

```rust
let state = get_lua();
assert_eq!(
    state
        .context(|ctx| -> String { ctx.load("return test_line:line()").call(()).unwrap() }),
            "A testing line"
);
```
becomes this:

```rust
test_lua!();
assert_lua_string!("test_line:line()", "A testing line");
```

And finally, this:

```rust
let state = get_lua();
let line = state.context(|ctx| -> Line { ctx.globals().get("test_line").unwrap() });
assert!(line.inner.flags.tts_gag);
```

becomes:

```rust
test_lua!();
let line: Line = global!("test_line");
assert!(line.inner.flags.tts_gag);
```

There's also a generic `assert_lua!()` for other types, which the others wrap:

```rust
test_lua!();
assert_lua!(usize, "123", 123);
```

The `test_lua!()` exists so we don't have to pass around the `state`, but we can surface that if it's convenient. 