### PR TITLE
Servers and settings on demand

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -286,14 +286,10 @@ impl EventHandler {
         }
     }
 
-    pub fn handle_store_events(
-        &mut self,
-        event: Event,
-        saved_servers: &mut Servers,
-        screen: &mut Screen,
-    ) -> Result {
+    pub fn handle_store_events(&mut self, event: Event, screen: &mut Screen) -> Result {
         match event {
             Event::AddServer(name, connection) => {
+                let mut saved_servers = Servers::load();
                 if saved_servers.contains_key(&name) {
                     self.session.main_writer.send(Event::Error(format!(
                         "Saved server already exists for {}",
@@ -312,6 +308,7 @@ impl EventHandler {
                 Ok(())
             }
             Event::RemoveServer(name) => {
+                let mut saved_servers = Servers::load();
                 if saved_servers.contains_key(&name) {
                     saved_servers.remove(&name);
                     saved_servers.save();
@@ -329,6 +326,7 @@ impl EventHandler {
                 Ok(())
             }
             Event::LoadServer(name) => {
+                let saved_servers = Servers::load();
                 if saved_servers.contains_key(&name) {
                     let connection = saved_servers.get(&name).cloned().unwrap();
                     self.session.main_writer.send(Event::Connect(connection))?;
@@ -339,6 +337,7 @@ impl EventHandler {
                 Ok(())
             }
             Event::ListServers => {
+                let saved_servers = Servers::load();
                 if saved_servers.is_empty() {
                     screen.print_info("There are no saved servers.");
                 } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,13 +229,11 @@ fn run(
     let mut transmit_writer: Option<Sender<TelnetData>> = None;
     let help_handler = HelpHandler::new(session.main_writer.clone());
     let mut event_handler = EventHandler::from(&session);
-    let mut saved_servers = Servers::load();
 
     let mut screen = Screen::new(session.tts_ctrl.clone(), settings.get(MOUSE_ENABLED)?)?;
     screen.setup()?;
 
-    let _input_thread =
-        spawn_input_thread(session.clone(), saved_servers.keys().cloned().collect());
+    let _input_thread = spawn_input_thread(session.clone());
     let _signal_thread = register_terminal_resize_listener(session.clone());
 
     let lua_scripts = {
@@ -294,7 +292,7 @@ For more info: https://github.com/LiquidityC/Blightmud/issues/173"#;
             | Event::RemoveServer(_)
             | Event::LoadServer(_)
             | Event::ListServers => {
-                event_handler.handle_store_events(event, &mut saved_servers, &mut screen)?;
+                event_handler.handle_store_events(event, &mut screen)?;
             }
             Event::MudOutput(_)
             | Event::Output(_)

--- a/src/tts/text_to_speech.rs
+++ b/src/tts/text_to_speech.rs
@@ -75,6 +75,10 @@ impl TTSController {
         tts_ctrl
     }
 
+    fn reload_settings(&mut self) {
+        self.settings = TTSSettings::load();
+    }
+
     fn send(&self, event: TTSEvent) {
         if let Some(rt) = &self.rt {
             match event {
@@ -93,15 +97,21 @@ impl TTSController {
     pub fn handle(&mut self, event: TTSEvent) {
         match event {
             TTSEvent::ChangeRate(rate) => {
+                self.reload_settings();
                 self.settings.rate += rate;
+                self.settings.save();
                 self.send(event);
             }
             TTSEvent::SetRate(rate) => {
+                self.reload_settings();
                 self.settings.rate = rate;
+                self.settings.save();
                 self.send(event);
             }
             TTSEvent::EchoKeys(enabled) => {
+                self.reload_settings();
                 self.settings.echo_keys = enabled;
+                self.settings.save();
             }
             _ => {
                 self.send(event);
@@ -165,9 +175,6 @@ impl TTSController {
 
     pub fn shutdown(&self) {
         if let Some(rt) = &self.rt {
-            if !cfg!(test) {
-                self.settings.save();
-            }
             rt.send(TTSEvent::Shutdown).ok();
         }
     }

--- a/src/ui/command.rs
+++ b/src/ui/command.rs
@@ -1,4 +1,4 @@
-use crate::model::{Connection, Line};
+use crate::model::{Connection, Line, Servers};
 use crate::{event::Event, tts::TTSController};
 use crate::{lua::LuaScript, lua::UiEvent, session::Session, SaveData};
 use log::debug;
@@ -407,7 +407,7 @@ fn handle_script_ui_io(
     }
 }
 
-pub fn spawn_input_thread(session: Session, saved_servers: Vec<String>) -> thread::JoinHandle<()> {
+pub fn spawn_input_thread(session: Session) -> thread::JoinHandle<()> {
     thread::Builder::new()
         .name("input-thread".to_string())
         .spawn(move || {
@@ -417,7 +417,7 @@ pub fn spawn_input_thread(session: Session, saved_servers: Vec<String>) -> threa
             let stdin = stdin();
             let mut tts_ctrl = session.tts_ctrl.clone();
             let mut buffer = CommandBuffer::new(tts_ctrl.clone());
-            for server in saved_servers {
+            for server in Servers::load().keys() {
                 buffer.completion_tree.insert(&server);
             }
             buffer


### PR DESCRIPTION
This changes `Settings`, `Servers`, and `TTSSettings` to always call `load()` before `save()`, and to always call `save()` after making any changes.

In other words, `/add_server` will first call `Servers::load()` to make sure it's got the latest list and then call `Server::save()` to make sure the new server is saved right away. Same with all the commands that modify settings or tts settings.

This should be enough to close #195, as I don't think anything else saves on exit except for the `History` stuff. The `store` commands (Lua API) already work this way. 

You can try this out by changing a setting like `confirm_quit` while the app is running and watch it take effect right away. Same thing with listing servers with `/ls`. 