### PR TITLE
Fixes home key crash

### DIFF
--- a/src/ui/screen.rs
+++ b/src/ui/screen.rs
@@ -502,9 +502,11 @@ impl Screen {
     }
 
     pub fn scroll_top(&mut self) -> Result<()> {
-        self.scroll_data.0 = true;
-        self.scroll_data.1 = 0;
-        self.draw_scroll()?;
+        if self.history.inner.len() as u16 >= self.output_line {
+            self.scroll_data.0 = true;
+            self.scroll_data.1 = 0;
+            self.draw_scroll()?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Needed to check if there's any history before trying to scroll. If there's a better approach please let me know, but I think this fixes #211. 