### PR TITLE
Fix issue with prompts longer than 80 characters

### DIFF
--- a/src/net/output_buffer.rs
+++ b/src/net/output_buffer.rs
@@ -90,10 +90,6 @@ impl OutputBuffer {
     pub fn is_empty(&self) -> bool {
         self.buffer.is_empty()
     }
-
-    pub fn len(&self) -> usize {
-        self.buffer.len()
-    }
 }
 
 #[cfg(test)]

--- a/src/net/telnet.rs
+++ b/src/net/telnet.rs
@@ -119,10 +119,8 @@ impl TelnetHandler {
     pub fn handle_prompt(&mut self) {
         if self.mode == TelnetMode::UnterminatedPrompt {
             if let Ok(mut output_buffer) = self.output_buffer.lock() {
-                if output_buffer.len() < 80 {
-                    output_buffer.buffer_to_prompt(false);
-                    self.main_writer.send(Event::Prompt).unwrap();
-                }
+                output_buffer.buffer_to_prompt(false);
+                self.main_writer.send(Event::Prompt).unwrap();
             }
         }
     }


### PR DESCRIPTION
For prompts longer than 80 characters it wasn't handle correctly. This limit seems to be unnecessary.