### PR TITLE
Changes /test command to not strip all whitespace

### DIFF
--- a/resources/lua/macros.lua
+++ b/resources/lua/macros.lua
@@ -7,7 +7,7 @@ alias.add("^/test$", function (matches)
 end)
 
 alias.add("^/test (.*)$", function (matches)
-	local line = matches[2]:gsub("%s+", "")
+	local line = matches[2]:gsub("%s+", " ")
 	if line:len() > 0 then
 		blight:mud_output(line)
 	else


### PR DESCRIPTION
I think this is probably just a typo and not intentional. 

Before:

```
> /test one two three
onetwothree
```

After:

```
> /test one two three
one two three
```