### PR TITLE
Move logging functions to separate module (#208)

### DIFF
--- a/resources/help/changes.md
+++ b/resources/help/changes.md
@@ -39,6 +39,10 @@ See `/help alias` for more information.
 - `blight:user_input(...)` => `mud.input(...)`
 - `blight:mud_output(...)` => `mud.output(...)`
 
+## Logging
+- `blight:start_log(...)` => `log.start(...)`
+- `blight:stop_log(...)` => `log.stop(...)`
+
 ## Scripts
 - `blight:load(...)` => `script.load(...)`
 - `blight:reset()` => `script.reset()`

--- a/resources/help/log.md
+++ b/resources/help/log.md
@@ -1,0 +1,18 @@
+# Log
+
+This module allows you to interact with the logging capabilities of Blightmud.
+
+##
+
+***log.start(worldname)***
+Start logging to a specified "world" name.
+
+If a log is already started then this command has no effect. So if you choose to use this manual logging then make
+sure automatic logging is disabled. See `/help logging` for more information.
+
+- `worldname` Folder to write logs.
+
+##
+
+***log.stop()***
+Stop logging.

--- a/resources/help/lua_blight.md
+++ b/resources/help/lua_blight.md
@@ -29,17 +29,3 @@ Gets the current terminal dimensions (these can change on window resize).
 ```lua
 width, height = blight:terminal_dimensions()
 ```
-
-##
-
-***blight:start_logging(worldname)***
-Start logging to a specified "world" name.
-
-If a log is already started then this command has no effect. So if you choose to use this manual logging then make
-sure automatic logging is disabled. See `/help logging` for more information.
-
-##
-
-***blight:stop_logging()***
-Stop logging
-

--- a/resources/help/scripting.md
+++ b/resources/help/scripting.md
@@ -26,4 +26,5 @@ by typing `/help <module>`.
 - `bindings`    Functions for configuring keybindings and adding new ones
 - `tasks`       Library for control of background tasks
 - `mud`         Functions for interacting with the mud
+- `log`         Functions for logging
 - `core`        Functions for advanced scripting and telnet protocol control

--- a/src/lua/blight.rs
+++ b/src/lua/blight.rs
@@ -130,16 +130,6 @@ impl UserData for Blight {
                 })
             },
         );
-        methods.add_method("start_log", |_, this, name: String| {
-            this.main_writer
-                .send(Event::StartLogging(name, true))
-                .unwrap();
-            Ok(())
-        });
-        methods.add_method("stop_log", |_, this, _: ()| {
-            this.main_writer.send(Event::StopLogging).unwrap();
-            Ok(())
-        });
         methods.add_method("is_core_mode", |_, this, ()| Ok(this.core_mode));
         methods.add_method_mut(
             "add_timer",

--- a/src/lua/log.rs
+++ b/src/lua/log.rs
@@ -1,0 +1,71 @@
+use rlua::{UserData, UserDataMethods};
+
+use super::{backend::Backend, constants::BACKEND};
+use crate::event::Event;
+
+pub struct Log {}
+
+impl Log {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl UserData for Log {
+    fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
+        methods.add_function("start", |ctx, name: String| {
+            let backend: Backend = ctx.named_registry_value(BACKEND)?;
+            backend
+                .writer
+                .send(Event::StartLogging(name, true))
+                .unwrap();
+            Ok(())
+        });
+        methods.add_function("stop", |ctx, _: ()| {
+            let backend: Backend = ctx.named_registry_value(BACKEND)?;
+            backend.writer.send(Event::StopLogging).unwrap();
+            Ok(())
+        });
+    }
+}
+
+#[cfg(test)]
+mod test_log {
+    use std::sync::mpsc::{channel, Receiver, Sender};
+
+    use rlua::Lua;
+
+    use crate::{
+        event::Event,
+        lua::{backend::Backend, constants::BACKEND},
+    };
+
+    use super::Log;
+
+    fn assert_event(lua_code: &str, event: Event) {
+        let (writer, reader): (Sender<Event>, Receiver<Event>) = channel();
+        let backend = Backend::new(writer);
+        let log = Log::new();
+        let lua = Lua::new();
+        lua.context(|ctx| {
+            ctx.set_named_registry_value(BACKEND, backend).unwrap();
+            ctx.globals().set("log", log).unwrap();
+            ctx.load(lua_code).exec().unwrap();
+        });
+
+        assert_eq!(reader.recv(), Ok(event));
+    }
+
+    #[test]
+    fn test_start() {
+        assert_event(
+            "log.start(\"some_name\")",
+            Event::StartLogging("some_name".to_string(), true),
+        );
+    }
+
+    #[test]
+    fn test_stop() {
+        assert_event("log.stop()", Event::StopLogging);
+    }
+}

--- a/src/lua/lua_script.rs
+++ b/src/lua/lua_script.rs
@@ -3,7 +3,7 @@ use super::{
     util::expand_tilde,
 };
 use super::{constants::*, core::Core, ui_event::UiEvent};
-use super::{mud::Mud, regex::RegexLib, util::*};
+use super::{log::Log, mud::Mud, regex::RegexLib, util::*};
 use crate::{event::Event, model::Line};
 use anyhow::Result;
 use rlua::{Lua, Result as LuaResult};
@@ -44,6 +44,7 @@ fn create_default_lua_state(
         globals.set("tts", tts)?;
         globals.set("regex", RegexLib {})?;
         globals.set("mud", Mud::new())?;
+        globals.set("log", Log::new())?;
         globals.set("script", Script {})?;
 
         globals.set(TIMED_FUNCTION_TABLE, ctx.create_table()?)?;
@@ -624,21 +625,6 @@ mod lua_script_tests {
             "mud.send(\"message\")",
             vec![Event::ServerInput(Line::from("message"))],
         );
-    }
-
-    #[test]
-    fn test_logging() {
-        let (lua, reader) = get_lua();
-        lua.state.context(|ctx| {
-            ctx.load("blight:start_log(\"testworld\")").exec().unwrap();
-            ctx.load("blight:stop_log()").exec().unwrap();
-        });
-
-        assert_eq!(
-            reader.recv(),
-            Ok(Event::StartLogging("testworld".to_string(), true))
-        );
-        assert_eq!(reader.recv(), Ok(Event::StopLogging));
     }
 
     #[test]

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -10,6 +10,7 @@ mod constants;
 mod core;
 mod exec_response;
 mod line;
+mod log;
 mod lua_script;
 mod mud;
 mod regex;

--- a/src/main.rs
+++ b/src/main.rs
@@ -365,12 +365,10 @@ For more info: https://github.com/LiquidityC/Blightmud/issues/173"#;
             },
             Event::StartLogging(world, force) => {
                 if Settings::load().get(LOGGING_ENABLED)? || force {
-                    screen.print_info(&format!("Started logging for: {}", world));
                     session.start_logging(&world)
                 }
             }
             Event::StopLogging => {
-                screen.print_info("Logging stopped");
                 session.stop_logging();
             }
             Event::EnableProto(proto) => {

--- a/src/session.rs
+++ b/src/session.rs
@@ -96,6 +96,11 @@ impl Session {
 
     pub fn start_logging(&self, host: &str) {
         if let Ok(mut logger) = self.logger.lock() {
+            self.main_writer
+                .send(Event::Info(
+                    format!("Started logging for: {}", host).to_string(),
+                ))
+                .unwrap();
             logger.start_logging(host).ok();
         }
     }
@@ -252,6 +257,10 @@ mod session_test {
         let (session, reader, _timer_reader) = build_session();
         assert!(!session.logger.lock().unwrap().is_logging());
         session.start_logging("mysteryhost");
+        assert_eq!(
+            reader.recv(),
+            Ok(Event::Info("Started logging for: mysteryhost".to_string()))
+        );
         assert!(session.logger.lock().unwrap().is_logging());
         session.stop_logging();
         assert_eq!(

--- a/src/ui/help_handler.rs
+++ b/src/ui/help_handler.rs
@@ -150,6 +150,7 @@ fn load_files() -> HashMap<&'static str, &'static str> {
         "regex" => "regex.md",
         "line" => "line.md",
         "mud" => "mud.md",
+        "log" => "log.md",
         "config_scripts" => "config_scripts.md",
         "scripting" => "scripting.md",
         "settings" => "settings.md",


### PR DESCRIPTION
* start_log and stop_log functions moved to separate log module

* Actualizes help files about scripting and changes

* Fixes problem with duplication of messages about logging stop

As described in #194